### PR TITLE
fix linkedin oauth authorisation endpoint

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -93,7 +93,7 @@ export default {
     linkedin: {
       name: 'linkedin',
       url: '/auth/linkedin',
-      authorizationEndpoint: 'https://www.linkedin.com/uas/oauth2/authorization',
+      authorizationEndpoint: 'https://www.linkedin.com/oauth/v2/authorization',
       redirectUri: null,
       requiredUrlParams: ['state'],
       scope: ['r_emailaddress'],


### PR DESCRIPTION
The current endpoint throws an error in vue-authenticate "Invalid OAuth type", updating endpoint to the officially documented (https://developer.linkedin.com/docs/oauth2) one fixes this