### PR TITLE
Add Baidu provider

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -150,6 +150,18 @@ export default {
       popupOptions: { width: 500, height: 560 }
     },
 
+    baidu: {
+      name: 'baidu',
+      url: '/auth/baidu',
+      authorizationEndpoint: 'https://openapi.baidu.com/oauth/2.0/authorize',
+      redirectUri: window.location.origin,
+      requiredUrlParams: ['scope'],
+      scope: ['basic'],
+      scopeDelimiter: ' ',
+      oauthType: '2.0',
+      popupOptions: { width: 452, height: 633 },
+    },
+
     oauth1: {
       name: null,
       url: '/auth/oauth1',


### PR DESCRIPTION
Thanks for writing such a great plugin!

This is a small PR that adds Baidu as an OAuth provider.

Here are [Baidu's docs](http://developer.baidu.com/wiki/index.php?title=docs/oauth) for reference. They're written in Chinese, but you can get the gist of it by sending it through Google Translate.