### PR TITLE
fix typo in session-storage.js

### DIFF
--- a/src/storage/session-storage.js
+++ b/src/storage/session-storage.js
@@ -1,4 +1,4 @@
-class LocalStorage {
+class SessionStorage {
   constructor(namespace) {
     this.namespace = namespace || null
   }
@@ -23,4 +23,4 @@ class LocalStorage {
   }
 }
 
-export default LocalStorage
+export default SessionStorage


### PR DESCRIPTION
Fix typo in session-storage.js
'LocalStorage' -> 'SessionStorage'