### PR TITLE
Return response from logout request

### DIFF
--- a/src/authenticate.js
+++ b/src/authenticate.js
@@ -176,6 +176,7 @@ export default class VueAuthenticate {
 
       return this.$http(requestOptions).then((response) => {
         this.storage.removeItem(this.tokenName)
+        return response
       })
     } else {
       this.storage.removeItem(this.tokenName)


### PR DESCRIPTION
To be consistent with `login()` and `register()` the request to `logout()` should return the HTTP response to the calling method.

This will allow developers who use `vue-authenticate` to implement the OpenID Connect "RP-Initiated Logout" flow which requires the client to be redirected to the OpenID Provider's (OP) logout endpoint URL after logging out of the OAuth2 web application.

For more info see https://openid.net/specs/openid-connect-session-1_0.html#RPLogout